### PR TITLE
feat: Fireball과 HealthPotion에 쿨다운 및 랜덤 효과 기능 추가

### DIFF
--- a/src/item/HealthPotion.ts
+++ b/src/item/HealthPotion.ts
@@ -1,14 +1,41 @@
 // 아이템 시스템
 
-import { Item } from './Item';
-import { Character } from '../character/Character';
+import { Item } from "./Item";
+import { Character } from "../character/Character";
 
 export class HealthPotion implements Item {
-  name = 'Health Potion';
+  name = "Health Potion";
+  cooldownTurns = 3;
+  currentCooldown = 0;
+
+  private getRandomHealAmount(): number {
+    const rand = Math.random();
+    if (rand < 0.5) return 30; // 50%
+    else if (rand < 0.9) return 40; // 45%
+    else return 70; // 5%
+  }
 
   use(user: Character): string {
-    const healed = Math.min(user.maxHp - user.hp, 50);
+    if (this.currentCooldown > 0) {
+      return `헬스 포션은 아직 ${this.currentCooldown}턴 남아 사용할 수 없습니다.`;
+    }
+
+    const healAmount = this.getRandomHealAmount();
+    const healed = Math.min(user.maxHp - user.hp, healAmount);
+
     user.hp += healed;
-    return `${user.name}가 Health Potion으로 ${healed}의 HP를 회복했습니다.`;
+    this.currentCooldown = this.cooldownTurns;
+
+    return `${user.name}가 헬스 포션으로 ${healed}의 HP를 회복했습니다. 다음 사용까지 ${this.cooldownTurns}턴 남았습니다.`;
+  }
+
+  isAvailable(): boolean {
+    return this.currentCooldown === 0;
+  }
+
+  advanceTurn(): void {
+    if (this.currentCooldown > 0) {
+      this.currentCooldown--;
+    }
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,6 +38,7 @@ function playerTurn(
 
   setTimeout(() => {
     fireball.advanceTurn(); // 쿨다운 감소
+    healthPotion.advanceTurn();
 
     const enemyMsg = battle.enemyAction();
     ui.log(enemyMsg);

--- a/src/skill/Fireball.ts
+++ b/src/skill/Fireball.ts
@@ -3,18 +3,25 @@ import { Character } from "../character/Character";
 
 export class Fireball implements Skill {
   name = "Fireball";
-  damage = 30;
   cooldownTurns = 5;
   currentCooldown = 0;
 
+  private getRandomDamage(): number {
+    const rand = Math.random();
+    if (rand < 0.7) return 20; // 70%
+    else if (rand < 0.9) return 25; // 20%
+    else return 40; // 10%
+  }
+
   use(user: Character, target: Character): string {
     if (this.currentCooldown > 0) {
-      return `${this.name}은 아직 ${this.currentCooldown}턴 남아 사용할 수 없습니다.`;
+      return `파이어볼은 아직 ${this.currentCooldown}턴 남아 사용할 수 없습니다.`;
     }
 
-    target.takeDamage(this.damage);
+    let damage = this.getRandomDamage();
+    target.takeDamage(damage);
     this.currentCooldown = this.cooldownTurns;
-    return `${user.name}가 ${target.name}에게 ${this.damage}의 파이어볼 데미지를 입혔습니다.`;
+    return `${user.name}가 ${target.name}에게 ${damage}의 파이어볼 데미지를 입혔습니다. 다음 사용까지 ${this.currentCooldown}턴 남았습니다.`;
   }
 
   isAvailable(): boolean {

--- a/src/skill/Fireball.ts
+++ b/src/skill/Fireball.ts
@@ -8,8 +8,8 @@ export class Fireball implements Skill {
 
   private getRandomDamage(): number {
     const rand = Math.random();
-    if (rand < 0.7) return 20; // 70%
-    else if (rand < 0.9) return 25; // 20%
+    if (rand < 0.6) return 20; // 60%
+    else if (rand < 0.9) return 25; // 30%
     else return 40; // 10%
   }
 

--- a/src/skill/Skill.ts
+++ b/src/skill/Skill.ts
@@ -1,9 +1,8 @@
 // 스킬 시스템
 
-import { Character } from '../character/Character';
+import { Character } from "../character/Character";
 
 export interface Skill {
   name: string;
-  damage: number;
   use(user: Character, target: Character): string;
 }


### PR DESCRIPTION
## 개요
- `HealthPotion` 클래스에 쿨다운 기능을 추가하고, 효과가 랜덤하게 적용되도록 기능을 확장했습니다.

## 주요 변경사항
- `Fireball`
  - 고정 데미지에서 확률 기반 데미지(20, 25, 40)로 변경
  - 각각 60%, 30%, 10%
  - 사용 후 5턴 쿨다운 적용
- `HealthPotion`
  - 회복량을 30/40/70 중 확률적으로 결정
  - 각각 50%, 45%, 5%
  - 사용 후 3턴 쿨다운 적용
- `main.ts`
  - 매 턴마다 `advanceTurn()`을 호출하여 각 스킬/아이템의 쿨다운 감소
